### PR TITLE
Fixed wrong elementwise multiplication of matrices

### DIFF
--- a/nearest_correlation.py
+++ b/nearest_correlation.py
@@ -106,7 +106,7 @@ def nearcorr(A, tol=[], flag=0, max_iterations=100, n_pos_eig=0,
 
         Xold = copy(X)
         R = X - ds
-        R_wtd = Whalf*R
+        R_wtd = np.multiply(Whalf,R)
         if flag == 0:
             X = proj_spd(R_wtd)
         elif flag == 1:


### PR DESCRIPTION
I have rewritten your/Nick's approach to the C++ (it will shortly appear in the github), and I found the following bug in your implementation. The original MATLAB implementation does elementwise multiplication at this point.  Thus, I fixed it to elementwise multiplication also in Python.

I do not have time to test this change in Python environment, but with classic matrix multiplication, the results in C++ implementation were wrong, and with elementwise multiplication, the results seem to be OK.